### PR TITLE
Improve project settings' manageability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ branches:
   only:
     - master
 script:
-  - dotnet build -c Release --no-cache ./src/HappyCode.NetCoreBoilerplate.Api/
-  - dotnet test ./test/HappyCode.NetCoreBoilerplate.Api.IntegrationTests/
-  - dotnet test ./test/HappyCode.NetCoreBoilerplate.Api.UnitTests/
-  - dotnet test ./test/HappyCode.NetCoreBoilerplate.Core.UnitTests/
+  - dotnet build -c Release --no-cache ./NetCoreBoilerplate.sln
+  - dotnet test -c Release --no-build ./NetCoreBoilerplate.sln
 notifications:
   email:
     recipients:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Copyright>Copyright © happy+code 2019</Copyright>
   </PropertyGroup>
   <PropertyGroup>
-    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)HappyCode.NetCoreBoilerplate.ruleset</CodeAnalysisRuleSet>
  </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Łukasz Kurzyniec</Authors>
+    <Copyright>Copyright © happy+code 2019</Copyright>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)HappyCode.NetCoreBoilerplate.ruleset</CodeAnalysisRuleSet>
+ </PropertyGroup>
+</Project>

--- a/NetCoreBoilerplate.sln
+++ b/NetCoreBoilerplate.sln
@@ -1,0 +1,60 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6D3497A0-339F-4545-86B8-7E015B468025}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8AC3899F-4C0B-4EF6-AD2B-97D91FE107F5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Api", "src\HappyCode.NetCoreBoilerplate.Api\HappyCode.NetCoreBoilerplate.Api.csproj", "{C29597BD-2BE6-4E35-B6BF-E3D416AE3661}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Core", "src\HappyCode.NetCoreBoilerplate.Core\HappyCode.NetCoreBoilerplate.Core.csproj", "{C658A533-24EC-4586-81E7-C51D2F217945}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Api.IntegrationTests", "test\HappyCode.NetCoreBoilerplate.Api.IntegrationTests\HappyCode.NetCoreBoilerplate.Api.IntegrationTests.csproj", "{89F377EB-45A8-404D-861D-78B41B73C19D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Api.UnitTests", "test\HappyCode.NetCoreBoilerplate.Api.UnitTests\HappyCode.NetCoreBoilerplate.Api.UnitTests.csproj", "{1606FA62-EA72-4F99-971C-0DA67D910188}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Core.UnitTests", "test\HappyCode.NetCoreBoilerplate.Core.UnitTests\HappyCode.NetCoreBoilerplate.Core.UnitTests.csproj", "{E7FD0B44-8ACA-4EA6-8A38-E6D346462273}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C29597BD-2BE6-4E35-B6BF-E3D416AE3661}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C29597BD-2BE6-4E35-B6BF-E3D416AE3661}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C29597BD-2BE6-4E35-B6BF-E3D416AE3661}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C29597BD-2BE6-4E35-B6BF-E3D416AE3661}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C658A533-24EC-4586-81E7-C51D2F217945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C658A533-24EC-4586-81E7-C51D2F217945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C658A533-24EC-4586-81E7-C51D2F217945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C658A533-24EC-4586-81E7-C51D2F217945}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89F377EB-45A8-404D-861D-78B41B73C19D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89F377EB-45A8-404D-861D-78B41B73C19D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89F377EB-45A8-404D-861D-78B41B73C19D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89F377EB-45A8-404D-861D-78B41B73C19D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1606FA62-EA72-4F99-971C-0DA67D910188}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1606FA62-EA72-4F99-971C-0DA67D910188}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1606FA62-EA72-4F99-971C-0DA67D910188}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1606FA62-EA72-4F99-971C-0DA67D910188}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7FD0B44-8ACA-4EA6-8A38-E6D346462273}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7FD0B44-8ACA-4EA6-8A38-E6D346462273}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7FD0B44-8ACA-4EA6-8A38-E6D346462273}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7FD0B44-8ACA-4EA6-8A38-E6D346462273}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C29597BD-2BE6-4E35-B6BF-E3D416AE3661} = {6D3497A0-339F-4545-86B8-7E015B468025}
+		{C658A533-24EC-4586-81E7-C51D2F217945} = {6D3497A0-339F-4545-86B8-7E015B468025}
+		{89F377EB-45A8-404D-861D-78B41B73C19D} = {8AC3899F-4C0B-4EF6-AD2B-97D91FE107F5}
+		{1606FA62-EA72-4F99-971C-0DA67D910188} = {8AC3899F-4C0B-4EF6-AD2B-97D91FE107F5}
+		{E7FD0B44-8ACA-4EA6-8A38-E6D346462273} = {8AC3899F-4C0B-4EF6-AD2B-97D91FE107F5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FE6D8568-233C-4A49-84FF-2FE6C0DE238C}
+	EndGlobalSection
+EndGlobal

--- a/NetCoreBoilerplate.sln
+++ b/NetCoreBoilerplate.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6D3497A0-339F-4545-86B8-7E015B468025}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8AC3899F-4C0B-4EF6-AD2B-97D91FE107F5}"
+	ProjectSection(SolutionItems) = preProject
+		test\Directory.Build.props = test\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Api", "src\HappyCode.NetCoreBoilerplate.Api\HappyCode.NetCoreBoilerplate.Api.csproj", "{C29597BD-2BE6-4E35-B6BF-E3D416AE3661}"
 EndProject
@@ -16,6 +19,15 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Api.UnitTests", "test\HappyCode.NetCoreBoilerplate.Api.UnitTests\HappyCode.NetCoreBoilerplate.Api.UnitTests.csproj", "{1606FA62-EA72-4F99-971C-0DA67D910188}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HappyCode.NetCoreBoilerplate.Core.UnitTests", "test\HappyCode.NetCoreBoilerplate.Core.UnitTests\HappyCode.NetCoreBoilerplate.Core.UnitTests.csproj", "{E7FD0B44-8ACA-4EA6-8A38-E6D346462273}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A9D8D97C-B58E-4A12-A7FE-D93A71CFFB73}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.travis.yml = .travis.yml
+		Directory.Build.props = Directory.Build.props
+		HappyCode.NetCoreBoilerplate.ruleset = HappyCode.NetCoreBoilerplate.ruleset
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/HappyCode.NetCoreBoilerplate.Api/HappyCode.NetCoreBoilerplate.Api.csproj
+++ b/src/HappyCode.NetCoreBoilerplate.Api/HappyCode.NetCoreBoilerplate.Api.csproj
@@ -1,27 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <Authors>Łukasz Kurzyniec</Authors>
-    <Copyright>Copyright © happy+code 2019</Copyright>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <CodeAnalysisRuleSet>../../HappyCode.NetCoreBoilerplate.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.7" />

--- a/src/HappyCode.NetCoreBoilerplate.Core/HappyCode.NetCoreBoilerplate.Core.csproj
+++ b/src/HappyCode.NetCoreBoilerplate.Core/HappyCode.NetCoreBoilerplate.Core.csproj
@@ -1,22 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <CodeAnalysisRuleSet>../../HappyCode.NetCoreBoilerplate.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/test/HappyCode.NetCoreBoilerplate.Api.IntegrationTests/HappyCode.NetCoreBoilerplate.Api.IntegrationTests.csproj
+++ b/test/HappyCode.NetCoreBoilerplate.Api.IntegrationTests/HappyCode.NetCoreBoilerplate.Api.IntegrationTests.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />

--- a/test/HappyCode.NetCoreBoilerplate.Api.UnitTests/HappyCode.NetCoreBoilerplate.Api.UnitTests.csproj
+++ b/test/HappyCode.NetCoreBoilerplate.Api.UnitTests/HappyCode.NetCoreBoilerplate.Api.UnitTests.csproj
@@ -1,10 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.0" />

--- a/test/HappyCode.NetCoreBoilerplate.Core.UnitTests/HappyCode.NetCoreBoilerplate.Core.UnitTests.csproj
+++ b/test/HappyCode.NetCoreBoilerplate.Core.UnitTests/HappyCode.NetCoreBoilerplate.Core.UnitTests.csproj
@@ -1,10 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.0" />


### PR DESCRIPTION
I've changed a couple of o things:

- Added sln file to facilitate project development in Visual Studio and Rider. This also simplify CI script and helps to avoid situation when somebody adds another test project and forgot to add it in CI definition.

- Move common settings to `Directory.Build.props` file. This will simplify changing properties in the future and enforce consistency across all the projects.

- Enable code analysis on the build to enforce all configured rules in CI