### PR TITLE
Flush logger on normal application shut-down

### DIFF
--- a/src/HappyCode.NetCoreBoilerplate.Api/Program.cs
+++ b/src/HappyCode.NetCoreBoilerplate.Api/Program.cs
@@ -22,8 +22,11 @@ namespace HappyCode.NetCoreBoilerplate.Api
             catch (Exception ex)
             {
                 Log.Logger.Fatal(ex, "Application start-up failed");
-                Log.CloseAndFlush();
                 throw;
+            }
+            finally
+            {
+                Log.CloseAndFlush();
             }
         }
 


### PR DESCRIPTION
`Log.CloseAndFlush()` is also necessary when the application shuts down normally. Cheers!